### PR TITLE
[fix] create and update API Receive response type 400 to 200

### DIFF
--- a/controller/post-controller.go
+++ b/controller/post-controller.go
@@ -98,7 +98,7 @@ func CreatePost(c *gin.Context) {
 	db = database.GetDB()
 	var post Post
 
-	c.BindJSON(&post)
+	c.ShouldBindJSON(&post)
 
 	if err := db.Create(&post).Error; err != nil {
 		fmt.Println(err)
@@ -120,7 +120,7 @@ func UpdatePost(c *gin.Context) {
 		return
 	}
 
-	c.BindJSON(&post)
+	c.ShouldBindJSON(&post)
 
 	db.Save(&post)
 	c.JSON(200, post)


### PR DESCRIPTION
I fixed it because there was a problem that the API Request of the gin framework is displayed as 400.