### PR TITLE
Fix hardcoded credentials, auth bypass, plaintext passwords, weak RNG

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,7 +9,9 @@ database:
 
 server:
   port: "8081"
-  secret: "mySecretKey"
+  # JWT secret MUST be set via JWT_SECRET environment variable
+  # Generate: openssl rand -base64 32
+  secret: ""
   accessTokenExpireDuration: 1 
   refreshTokenExpireDuration: 1
   limitCountPerRequest: 1 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/viper"
@@ -52,7 +53,6 @@ func Load(configPath ...string) (*Config, error) {
 	v.SetDefault("database.driver", "sqlite")
 	v.SetDefault("database.dbname", "ugin")
 	v.SetDefault("database.logmode", true)
-	v.SetDefault("jwt.secret", "change-me-in-production")
 	v.SetDefault("jwt.accessTokenExpireDuration", 1)
 	v.SetDefault("jwt.refreshTokenExpireDuration", 24)
 
@@ -98,10 +98,11 @@ func Load(configPath ...string) (*Config, error) {
 	// Build DSN based on driver
 	cfg.Database.DSN = buildDSN(cfg.Database)
 
-	// JWT config
+	// JWT config - secret MUST come from environment variable
 	cfg.JWT.Secret = v.GetString("server.secret")
 	if cfg.JWT.Secret == "" {
-		cfg.JWT.Secret = "change-me-in-production"
+		fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET is not set. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
 	}
 
 	accessTokenHours := v.GetInt("server.accessTokenExpireDuration")

--- a/internal/core/router.go
+++ b/internal/core/router.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -68,17 +71,12 @@ func setupAPIv1Routes(
 			auth.POST("/check", authHandler.CheckToken)
 		}
 
-		// Post routes (public)
+		// Post routes (read-only public, write JWT protected)
 		posts := v1.Group("/posts")
 		{
 			posts.GET("", postHandler.List)
 			posts.GET("/:id", postHandler.GetByID)
-			posts.POST("", postHandler.Create)
-			posts.PUT("/:id", postHandler.Update)
-			posts.DELETE("/:id", postHandler.Delete)
 		}
-
-		// Post routes (JWT protected)
 		postsJWT := v1.Group("/postsjwt")
 		postsJWT.Use(httpHandler.JWTAuth(authService))
 		{
@@ -93,10 +91,14 @@ func setupAPIv1Routes(
 
 // setupAdminRoutes sets up admin routes with basic auth
 func setupAdminRoutes(router *gin.Engine) {
+	adminUser := os.Getenv("ADMIN_USER")
+	adminPass := os.Getenv("ADMIN_PASS")
+	if adminUser == "" || adminPass == "" {
+		fmt.Fprintf(os.Stderr, "fatal: ADMIN_USER and ADMIN_PASS must be set for admin dashboard\n")
+		os.Exit(1)
+	}
 	authorized := router.Group("/admin", gin.BasicAuth(gin.Accounts{
-		"username1": "password1",
-		"username2": "password2",
-		"username3": "password3",
+		adminUser: adminPass,
 	}))
 	{
 		authorized.GET("/dashboard", httpHandler.Dashboard)

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -2,11 +2,14 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt"
+	"golang.org/x/crypto/bcrypt"
 	"github.com/yakuter/ugin/internal/domain"
 	"github.com/yakuter/ugin/internal/repository"
 )
@@ -59,9 +62,8 @@ func (s *authService) SignIn(ctx context.Context, creds *domain.Credentials) (*d
 		return nil, fmt.Errorf("sign in: %w", err)
 	}
 
-	// TODO: Use proper password hashing (bcrypt)
-	// For now, simple comparison (NOT PRODUCTION READY)
-	if user.MasterPassword != creds.MasterPassword {
+	// Verify password using bcrypt comparison
+	if err := bcrypt.CompareHashAndPassword([]byte(user.MasterPassword), []byte(creds.MasterPassword)); err != nil {
 		s.logger.Warn("invalid password attempt", "email", creds.Email)
 		return nil, ErrInvalidCredentials
 	}
@@ -82,12 +84,21 @@ func (s *authService) SignUp(ctx context.Context, creds *domain.Credentials) err
 		return repository.ErrInvalidInput
 	}
 
-	// TODO: Add password validation (min length, complexity, etc.)
-	// TODO: Hash password with bcrypt
+	// Validate password minimum length
+	if len(creds.MasterPassword) < 8 {
+		return repository.ErrInvalidInput
+	}
+
+	// Hash password with bcrypt before storing
+	hashed, err := bcrypt.GenerateFromPassword([]byte(creds.MasterPassword), bcrypt.DefaultCost)
+	if err != nil {
+		s.logger.Error("failed to hash password", "error", err)
+		return fmt.Errorf("hash password: %w", err)
+	}
 
 	user := &domain.User{
 		Email:          creds.Email,
-		MasterPassword: creds.MasterPassword, // TODO: Hash this!
+		MasterPassword: string(hashed),
 	}
 
 	if err := s.userRepo.Create(ctx, user); err != nil {
@@ -229,10 +240,13 @@ func (s *authService) parseToken(tokenString string) (*jwt.Token, error) {
 	return token, nil
 }
 
-// generateSecureKey generates a random secure key
+// generateSecureKey generates a random secure key using crypto/rand
 func generateSecureKey(length int) string {
-	// TODO: Use crypto/rand for production
-	// This is a placeholder
-	return fmt.Sprintf("%016x", time.Now().UnixNano())
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: should never happen, but avoid returning zero value
+		return hex.EncodeToString([]byte(fmt.Sprintf("%d", time.Now().UnixNano())))
+	}
+	return hex.EncodeToString(b)
 }
 


### PR DESCRIPTION
修复了5个安全问题：

### 1. CWE-798: JWT签名密钥硬编码 (Critical)
`config.yml:12` 和 `internal/config/config.go:55` 硬编码了JWT密钥 `"mySecretKey"` 和 `"change-me-in-production"`，攻击者可直接伪造任意用户的JWT token。

**修复**: 要求通过 `JWT_SECRET` 环境变量设置密钥，不设置则启动失败。

### 2. CWE-798: 管理员Basic Auth凭据硬编码 (Critical)
`internal/core/router.go:96-98` 硬编码了3组管理员用户名密码。

**修复**: 改为从 `ADMIN_USER`/`ADMIN_PASS` 环境变量读取。

### 3. CWE-306: /api/v1/posts 写操作缺少认证 (High)
`internal/core/router.go:74-79` POST/PUT/DELETE /api/v1/posts 没有任何认证保护，任何人可以创建、修改、删除文章。

**修复**: 写操作移至JWT保护的 /postsjwt 路由组，/posts 仅保留公开的GET读操作。

### 4. CWE-256: 密码明文存储 (High)
`internal/service/auth.go:67,91` 用户密码直接明文存储，无哈希处理。

**修复**: 使用 bcrypt 对密码进行哈希后再存储，登录时用 bcrypt.CompareHashAndPassword 验证。

### 5. CWE-330: 弱随机数生成 (Medium)
`internal/service/auth.go:236` transmission key使用 `time.Now().UnixNano()` 生成，可预测。

**修复**: 使用 `crypto/rand` 生成密码学安全随机数。

### PoC (JWT伪造)
已知 `config.yml` 默认密钥 `mySecretKey`:
```python
import jwt
token = jwt.encode({"email": "admin@ugin.com", "user_id": 1}, "mySecretKey", algorithm="HS256")
# curl -H "Authorization: Bearer $token" http://target:8081/api/v1/postsjwt
```

### PoC (无认证增删改)
```bash
# 无需任何token即可操作
curl -X POST http://target:8081/api/v1/posts -d '{"title":"hacked"}'
curl -X PUT http://target:8081/api/v1/posts/1 -d '{"title":"defaced"}'
curl -X DELETE http://target:8081/api/v1/posts/1
```